### PR TITLE
refacto: domains aliases

### DIFF
--- a/.env
+++ b/.env
@@ -9,6 +9,8 @@ LOG_LEVEL=debug
 
 # Allowed domains (seperate by comma)
 ALLOWED_DOMAINS=example.com
+# Domains aliases (seperate by comma)
+DOMAINS_ALIASES=example.com/secret=example
 
 # Storage: "local" ou "s3"
 STORAGE_DRIVER=s3

--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Edit .env.local to match your setup:
 ```
 APP_DEBUG=0
 
-ALLOWED_DOMAINS=mysite.com,another-site.com=domain_alias
+ALLOWED_DOMAINS=mysite.com,another-site.com
+DOMAINS_ALIASES=another-site.com/secret-images=another
+
 STORAGE_TYPE=local # "local" or "s3"
 
 # Local storage configuration

--- a/src/ContainerConfig.php
+++ b/src/ContainerConfig.php
@@ -39,23 +39,18 @@ final class ContainerConfig extends Container
         $this['storage_path'] = $this->getEnv('STORAGE_PATH');
         $this['cache_ttl'] = (int) $this->getEnv('CACHE_TTL');
 
-        $allowedDomains = [];
         $domainsAliases = [];
-        foreach (explode(',', $this->getEnv('ALLOWED_DOMAINS')) as $domain) {
-            if (true === str_contains($domain, '=')) {
-                $parts = explode('=', $domain);
-
-                $allowedDomains[] = $parts[0];
-                $domainsAliases[$parts[1]] = $parts[0];
-
-                continue;
+        foreach (explode(',', $this->getEnv('DOMAINS_ALIASES')) as $domain) {
+            if (false === str_contains($domain, '=')) {
+                throw new \InvalidArgumentException("Domain alias must contain '='.");
             }
 
-            $allowedDomains[] = $domain;
+            $parts = explode('=', $domain);
+            $domainsAliases[$parts[1]] = $parts[0];
         }
-
-        $this['allowed_domains'] = $allowedDomains;
         $this['domains_aliases'] = $domainsAliases;
+
+        $this['allowed_domains'] = explode(',', $this->getEnv('ALLOWED_DOMAINS'));
 
         $this['image_compression'] = (int) $this->getEnv('IMAGE_COMPRESSION');
 

--- a/src/Decoder/UriDecoder.php
+++ b/src/Decoder/UriDecoder.php
@@ -46,7 +46,7 @@ final class UriDecoder
                 $uri = str_replace("_{$domainAlias}_", $domain, $uri);
             }
 
-            $uri = str_replace(['http://', 'http:/', 'https://', 'https:/'], '', $uri);
+            $uri = str_replace(['www.', 'http://', 'http:/', 'https://', 'https:/'], '', $uri);
 
             $this->finalUri = "https://$uri";
         }


### PR DESCRIPTION
Breaking change about var env `ALLOWED_DOMAINS`.

To alias a domain, use instead `DOMAINS_ALIASES`. Check _README.md_ for more information.